### PR TITLE
Tweak dev machine config

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This project is intended for the purposes of making it easy to share and maintain development environtment configuration for lessonly developers.
 
+When you receive your Lessonly MacBook, start here before setting up other tools.
+
 
 @TODO make this work for non-mac developers as well
 
@@ -9,46 +11,47 @@ This project is intended for the purposes of making it easy to share and maintai
 
 ## MacOS
 
-It is assumed you have homebrew installed.  
+1. Open a Terminal window and run `git`. This will prompt you to install Xcode tools. Install it.
+2. Open a browser window to https://github.com and log in to Github.
+3. Download and install [Docker for Mac](https://docs.docker.com/docker-for-mac/install/).
+    - Once you have it installed, run and log in to the Docker app. You may need to sign up if you haven't done this before.
+4. In your Terminal window, change to the directory where you want git repositories to go, and clone this repo.
+    ```sh
+    git clone https://github.com/lessonly/lldevconfig.git
+    cd lldevconfig
+    ```
+5. Run the bootstrap script
+    ```sh
+    bin/bootstrap
+    ```
+    - This will require user input a few times, including:
+    - Enter your computer password to install Homebrew
+    - Enter your computer password to change your default shell
+    - Enter the email address you use in Github to create your SSH key
+    - Enter a password to protect your SSH key
+    - Add your SSH key in Github. It should copy the key and open a page to [the Github SSH keys page](https://github.com/settings/keys) for you to make it easy.
+6. Open a new Terminal window and close the old one so that it loads zsh. This step is optional.
+7. `cd` to the `lldevconfig` project directory.
+8. Run the configuration script with `sudo`.
+    ```sh
+    sudo bin/lldevconfig
+    ```
+    - This sometimes fails to restart nginx and dnsmasq. If this happens, run the above command a second time. It usually works then.
+    - You may need to click "Allow" in a popup window for nginx.
+    - If you want to see what all is going to be performed before running it you can do the following:
+        ```sh
+        sudo bin/lldevconfig state.highstate test=True
+        ```
 
-Install salt (it does the heavy lifting)
+At this point, you have everything you need to clone a project and follow its setup instructions. We recommend visiting https://github.com/lessonly/lessonly and following the setup instructions there, first. That's our core app and most likely where you'll be spending more of your time.
 
-```brew install salt```
+## Other operating systems
 
-## Ubuntu
-
-
-[Install Salt Deb Repo](https://repo.saltstack.com/#ubuntu)
-
-After that is installed, ensure the mcrypt package is installed: 
-
-```apt-get install python-m2crypto```
-
-# run the scripts
-
-## Bootstrap the script
-
-This creates the .lldev directory, and sticks 2 configuration files in it.  `minions` you should never have to touch.   `grains` contains configuration options that we might want to change at some point based on preferences.
-
-```bin/bootstrap```
-
-
-## Run lldevconfig
-
-Run this command in sudo.  It will drop down to your user when it can.  I originally wanted to seperate the root level access from the user-level, but it is going to end up being different on different operating systems.
-
-```sudo bin/lldevconfig```
-
-And you should be done.
-
-If you want to see what all is going to be performed before running it you can do the following:
-
-``` sudo bin/lldevconfig state.highstate test=True```
-
+We don't officially support other operating systems right now.
 
 # How It works
 
-This is script uses salt to manage the state of your machine.  The goal is to stay out of your way and be a good citizen.  The goal is for all files to live in the ~/.lldev directory when possible.  There are other files (service, configurations that may have to be put elsewhere).
+This is script uses salt to manage the state of your machine.  The goal is to stay out of your way and be a good citizen.  The goal is for all files to live in the `~/.lldev` directory when possible.  There are other files (service, configurations that may have to be put elsewhere).
 
 ## Configuration
 
@@ -64,4 +67,16 @@ https://github.com/lessonly/lldevconfig/blob/master/base_config/grains
 
 - This script will start up an nginx instance that will serve as a reverse proxy to a rails backend on port 3000
 - This script also will generates a root CA, and trusts it for you.  It then signs a certificate for you that nginx will then use.
+
+## zsh
+
+This script sets up [zsh](http://zsh.sourceforge.net/) as your default shell. We recommend also installing [oh-my-zsh](https://ohmyz.sh/), which makes your shell much more useful.
+
+## asdf
+
+[asdf](https://asdf-vm.com) is a dependency version manager. It uses our `.tool-versions` files to determine what version of Ruby, NodeJS, Yarn, and other tools each project needs. It ensures the right versions are installed and used in the context of those projects.
+
+## Homebrew
+
+[Homebrew](https://brew.sh/) is a dependency manager which acts on a system level (whereas asdf works primarily on a project level).
 

--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -74,8 +74,12 @@ if [[ $? != 0 ]]; then
   read email
   ssh-keygen -f ~/.ssh/github -t rsa -b 4096 -C $email
 
+  echo "Adding SSH key to ssh-agent and keychain"
   eval "$(ssh-agent > /dev/null)"
-  ssh-add ~/.ssh/github
+  ssh-add -K ~/.ssh/github
+  if ! grep "~/.ssh/github" ~/.ssh/config; then
+    echo -e '\n\nHost Github\n  HostName github.com\n  AddKeysToAgent yes\n  UseKeychain yes\n  IdentityFile ~/.ssh/github' >> ~/.ssh/config
+  fi
 
   echo "SSH key generated. \033[1mAdd it to Github using these instructions:\033[0m https://help.github.com/en/articles/adding-a-new-ssh-key-to-your-github-account\n"
   cat ~/.ssh/github.pub

--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -51,18 +51,21 @@ else
 fi
 
 # Ensure zsh is installed
-echo "Installing zsh..."
-if [[ "$OSTYPE" == "linux-gnu" ]]; then
-  # Linux
-  sudo apt-get install zsh
-elif [[ "$OSTYPE" == "darwin"* ]]; then
-  # macOS
-  brew install zsh
+if ! which zsh > /dev/null; then
+  echo "Installing zsh..."
+  if [[ "$OSTYPE" == "linux-gnu" ]]; then
+    # Linux
+    sudo apt-get install zsh
+  elif [[ "$OSTYPE" == "darwin"* ]]; then
+    # macOS
+    brew install zsh
+  fi
 fi
 
 # Make zsh the default shell
 echo "Changing the default shell to zsh"
 chsh -s $(which zsh)
+touch ~/.zshrc
 
 stat ~/.ssh/github
 if [[ $? != 0 ]]; then

--- a/services/asdf.sls
+++ b/services/asdf.sls
@@ -1,33 +1,11 @@
 asdf:
-    git.cloned:
-        - name: https://github.com/asdf-vm/asdf.git
-        - target: {{ grains['user']['homedir']}}/.asdf
-        - branch: v0.7.2
-        - runas: {{ grains['user']['username']}}
-
-asdf-macos:
     cmd.run:
-        - name: echo -e '\n. $HOME/.asdf/asdf.sh\n. $HOME/.asdf/completions/asdf.bash' >> ~/.bash_profile
-        - unless: stat ~/.bashrc || stat ~/.bash_profile || stat ~/.zshrc
-        - runas: {{ grains['user']['username']}}
-
-asdf-bashrc:
-    cmd.run:
-        - name: echo -e '\n. $HOME/.asdf/asdf.sh\n. $HOME/.asdf/completions/asdf.bash' >> ~/.bashrc
-        - onlyif: stat ~/.bashrc
-        - unless: grep asdf.sh ~/.bashrc
-        - runas: {{ grains['user']['username']}}
-
-asdf-bash_profile:
-    cmd.run:
-        - name: echo -e '\n. $HOME/.asdf/asdf.sh\n. $HOME/.asdf/completions/asdf.bash' >> ~/.bash_profile
-        - onlyif: stat ~/.bash_profile
-        - unless: grep asdf.sh ~/.bash_profile
+        - name: git clone https://github.com/asdf-vm/asdf.git ~/.asdf && cd ~/.asdf && git checkout "$(git describe --abbrev=0 --tags)"
+        - unless: stat ~/.asdf
         - runas: {{ grains['user']['username']}}
 
 asdf-zshrc:
     cmd.run:
         - name: echo -e '\n. $HOME/.asdf/asdf.sh\n. $HOME/.asdf/completions/asdf.bash' >> ~/.zshrc
-        - onlyif: stat ~/.zshrc
         - unless: grep asdf.sh ~/.zshrc
         - runas: {{ grains['user']['username']}}


### PR DESCRIPTION
# Why

Resolves [[ch29250]](https://app.clubhouse.io/lessonly/story/29250)

There were a few hiccups in the dev machine setup process. This attempts to resolve those.

- We install zsh even if it's already installed. We should not do that.
- We don't ensure ~/.zshrc exists, but we should.
- We set the default shell incorrectly.
- asdf installs fine, but on subsequent runs salt fails because it attempts to install it again.
- We should add the github ssh key to the ssh agent permanently.

# What

This PR does the following things to resolve the above problems:

- Check for zsh before attempting to install it.
- Create `~/.zshrc` if it does not already exist.
- Install asdf by running the CLI commands unless `~/.asdf` exists. This prevents an attempted installation after asdf is already installed.
- Adds the SSH key to the Keychain so that on reboot, users don't need to re-add it to the SSH agent.
- Updates the README.md file with instructions based on the expanded setup.