### PR TITLE
Use the right ssh-agent command

### DIFF
--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -75,7 +75,7 @@ if [[ $? != 0 ]]; then
   ssh-keygen -f ~/.ssh/github -t rsa -b 4096 -C $email
 
   echo "Adding SSH key to ssh-agent and keychain"
-  eval "$(ssh-agent > /dev/null)"
+  eval "$(ssh-agent -s)"
   ssh-add -K ~/.ssh/github
   if ! grep "~/.ssh/github" ~/.ssh/config; then
     echo -e '\n\nHost Github\n  HostName github.com\n  AddKeysToAgent yes\n  UseKeychain yes\n  IdentityFile ~/.ssh/github' >> ~/.ssh/config


### PR DESCRIPTION
# Description

We were sending the output of `ssh-agent` to `/dev/null`, then `eval`uating the output of that command (which was just blank).

This updates that to run `ssh-agent -s` and `eval`uate the output of _that_ command, which is the right way to run ssh-agent on startup.