### PR TITLE
Add skills routes to go to 3001 and 3002 ports

### DIFF
--- a/services/nginx/nginx.conf
+++ b/services/nginx/nginx.conf
@@ -3,6 +3,14 @@ upstream rails {
     server 127.0.0.1:3000;
 }
 
+upstream skills-client {
+    server 127.0.0.1:3001;
+}
+
+upstream skills-server {
+    server 127.0.0.1:3002;
+}
+
 server {
     listen       {{ grains.get('dev_setup:lessonly_dev_ip_base', '127.0.0.1') }}:{{pillar['nginx']['http_port']}};
     server_name  lessonly.test *.lessonly.test default;
@@ -14,7 +22,20 @@ server {
         proxy_set_header X-Forwarded-For $remote_addr;
         proxy_set_header X-Forwarded-Proto $scheme;
     }
-
+    location ~ ^/skills/graphql/? {
+        proxy_pass http://skills-server;
+        proxy_set_header Host            $host;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Port 443;
+    }
+    location ~ ^/skills/? {
+        proxy_pass http://skills-client;
+        proxy_set_header Host            $host;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Port 443;
+    }
     #error_page  404              /404.html;
 
     # redirect server error pages to the static page /50x.html
@@ -49,5 +70,21 @@ server {
         proxy_set_header Host            $host;
         proxy_set_header X-Forwarded-For $remote_addr;
         proxy_set_header X-Forwarded-Proto $scheme;
+    }
+    
+    location ~ ^/skills/graphql/? {
+        proxy_pass http://skills-server;
+        proxy_set_header Host            $host;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Port 443;
+    }
+    location~ ^/skills/? {
+        proxy_pass http://skills-client;
+        proxy_set_header Host            $host;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Port 443;
+        absolute_redirect off;
     }
 }


### PR DESCRIPTION
## Why?

Resolves [[ch54647]](https://app.clubhouse.io/lessonly/story/54647)

We need a nicer way to develop on the skills app. We're starting to run into CORS issues and the logic to pull subdomains is getting harder unless we can use relative paths

## What?

This adds the routes /skills and /skills/graphql and proxies them to 3001 and 3002 respectively. 

## Testing Notes

- [ ] from the root of the project run `sudo bin/lldevconfig`
- [ ] once that's done restart nginx `brew services restart nginx`
- [ ] Run the core lessonly app and verify lessonly.test still works as expected
- [ ] go to https://dev.lessonly.test/skills and verify it does not show the core app and attempts to go to port 3001 (if you don't have the skills app installed try running something else on port 3001) 
- [ ] go to https://dev.lessonly.test/skills/graphql and verify it does not show the core app and attempts to go to port 3002 (if you don't have the skills app installed try running something else on port 3002) 