### PR TITLE
Increases proxy buffer size to support scout_apm...

### DIFF
--- a/services/nginx/nginx-MacOS.sls
+++ b/services/nginx/nginx-MacOS.sls
@@ -7,8 +7,10 @@ load-nginx-service:
         - runas: {{grains['user']['username']}} 
         - onchanges:
             - file: nginx.conf
+            - file: {{pillar['nginx']['server_file']}}
             - x509: test.lessonly.wildcard.crt
         - require:
             - pkg: nginx
+            - file: {{pillar['nginx']['server_file']}}
             - file: nginx.conf
             - x509: test.lessonly.wildcard.crt

--- a/services/nginx/nginx.conf
+++ b/services/nginx/nginx.conf
@@ -21,6 +21,9 @@ server {
         proxy_set_header Host            $host;
         proxy_set_header X-Forwarded-For $remote_addr;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_buffer_size          128k;
+        proxy_buffers              4 256k;
+        proxy_busy_buffers_size    256k;
     }
     location ~ ^/skills/graphql/? {
         proxy_pass http://skills-server;
@@ -70,6 +73,9 @@ server {
         proxy_set_header Host            $host;
         proxy_set_header X-Forwarded-For $remote_addr;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_buffer_size          128k;
+        proxy_buffers              4 256k;
+        proxy_busy_buffers_size    256k;
     }
     
     location ~ ^/skills/graphql/? {


### PR DESCRIPTION
...which sends performance insights (including query logs) via headers, which can get quite long for expensive pages and was leading to

```
upstream sent too big header
```

errors from nginx manifesting as 502 Gateway Unavailable errors in the browser.