### PR TITLE
Install swig and shared-mime-info

### DIFF
--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -49,6 +49,14 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then
   if [[ $? != 0 ]] ; then
     brew install salt
   fi
+
+  # bug with current salt setup which requires manually installing m2crypto which requires swig
+  echo "Installing swig"
+  brew list swig &>/dev/null || brew install swig
+
+  # lessons app needs this until we remove mimemagic dependency
+  echo "Installing shared-mime-info"
+  brew list shared-mime-info &>/dev/null || brew install shared-mime-info
 else
   echo "I don't know how to use this OS"
   exit 1


### PR DESCRIPTION
# Description

resolves [ch68521](https://app.clubhouse.io/lessonly/story/68521)

This PR adds two homebrew installations to the `bin/bootstrap` script.

1. `swig`: This is needed due to a bug in our x509 certificate creation process which requires m2crypto. m2crypto requires swig
2. `shared-mime-info`: This is needed due to a dependency in the mimemagic gem. We are working on removing this dependency in all of our apps, but until then installing `shared-mime-info` will prevent errors in our bundle installations