### PR TITLE
update proxy headers for https

### DIFF
--- a/services/nginx.sls
+++ b/services/nginx.sls
@@ -18,6 +18,5 @@ nginx.conf:
         - template: jinja
         - makedirs: True
         - user: {{ grains['user']['username'] }}
-        - require: 
+        - require:
             - pkg: nginx
-

--- a/services/nginx/nginx.conf
+++ b/services/nginx/nginx.conf
@@ -21,6 +21,7 @@ server {
         proxy_set_header Host            $host;
         proxy_set_header X-Forwarded-For $remote_addr;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Port 443;
         proxy_buffer_size          128k;
         proxy_buffers              4 256k;
         proxy_busy_buffers_size    256k;
@@ -40,7 +41,6 @@ server {
         proxy_set_header X-Forwarded-Port 443;
     }
     #error_page  404              /404.html;
-
     # redirect server error pages to the static page /50x.html
     #
     error_page   500 502 503 504  /50x.html;
@@ -72,12 +72,13 @@ server {
         proxy_pass http://rails;
         proxy_set_header Host            $host;
         proxy_set_header X-Forwarded-For $remote_addr;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Port 443;
         proxy_buffer_size          128k;
         proxy_buffers              4 256k;
         proxy_busy_buffers_size    256k;
     }
-    
+
     location ~ ^/skills/graphql/? {
         proxy_pass http://skills-server;
         proxy_set_header Host            $host;


### PR DESCRIPTION
There were some times when the backend (lessonly) wasn't detecting requests coming through https.  This makes api.lessonly.test work better with USE_SSL=true