### PR TITLE
Simplify bootstrap script to not force exist of zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ When you receive your Lessonly MacBook, start here before setting up other tools
     - This will require user input a few times, including:
     - Enter your computer password to install Homebrew
     - Enter your computer password to change your default shell
-    **Note:** this will launch a new instace of zsh. Type `exit` to continue running this script
     - Enter the email address you use in Github to create your SSH key
     - Enter a password to protect your SSH key (you will be asked 3 times)
     - Add your SSH key in Github. It should copy the key and open a page to [the Github SSH keys page](https://github.com/settings/keys) for you to make it easy.

--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -76,7 +76,9 @@ fi
 
 # Make zsh the default shell
 echo "Changing the default shell to zsh"
-chsh -s $(which zsh)
+echo "You will be prompted for your password"
+
+sh -c "chsh -s $(which zsh)"
 touch ~/.zshrc
 
 # Install oh-my-zsh


### PR DESCRIPTION
This launches a new shell to change  the shell in.  This doesn't drop the user into a new zsh shell simplifying the process. This also removed the reference to quitting the ZSH from the readme.