### PR TITLE
Remove skills reverse proxy headers

### DIFF
--- a/bin/Caddyfile
+++ b/bin/Caddyfile
@@ -34,14 +34,8 @@ lessonly.test:8443,
 		header_up Host {upstream_hostport}
 		header_up X-Forwarded-Host {host}
 	}
-	reverse_proxy /skills* 127.0.0.1:3001 {
-		header_up Host {upstream_hostport}
-		header_up X-Forwarded-Host {host}
-	}
-	reverse_proxy /skills/graphql* 127.0.0.1:3002 {
-		header_up Host {upstream_hostport}
-		header_up X-Forwarded-Host {host}
-	}
+	reverse_proxy /skills* 127.0.0.1:3001
+	reverse_proxy /skills/graphql* 127.0.0.1:3002
 }
 
 # to test if port forwarding, dnsmasq, and caddy are working:


### PR DESCRIPTION
## Why?

Skills is receiving the wrong host from Caddy in the headers

## What?

This removes the header_up from the two reverse proxy settings for the skills paths

## Testing Notes


### Setup/Preparation:

- [ ] run `bin/bootstrap`
- [ ] set up the skills app

### Feature testing steps:

- [ ] run the core app and skills app and verify skills loads

## Merge Instructions

Please **DO** squash my commits when merging
