### PR TITLE
Better handle configuring M1 macs

### DIFF
--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -50,6 +50,8 @@ brew services restart caddy
 # dnsmasq handles the local dns translation from *.lessonly.test -> 127.0.0.1
 # install dnsmasq config
 cp bin/dnsmasq.conf $(brew --prefix)/etc/dnsmasq.conf
+# make /etc/resolver directory if it does not exist
+sudo mkdir -p /etc/resolver
 # install our resolver
 sudo cp bin/lessonly-resolver /etc/resolver/lessonly.test
 # stop (if necessary) and start the service formula immediately and register it to launch at boot.

--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -62,9 +62,9 @@ sudo brew services restart dnsmasq
 # copy port forwarding anchor file
 sudo cp bin/test.lessonly.anchor /etc/pf.anchors/test.lessonly
 # copy boot script to setup port forwarding
-cp bin/lldev-network-setup.sh /usr/local/bin/lldev-network-setup.sh
+sudo cp bin/lldev-network-setup.sh /usr/local/bin/lldev-network-setup.sh
 # manually run script
-sudo /usr/local/bin/lldev-network-setup.sh
+sudo sh /usr/local/bin/lldev-network-setup.sh
 # set script to run on boot
 pfservice=$(sudo launchctl list | grep test.lessonly.network-setup)
 if [ ! "$pfservice" ] ; then
@@ -114,7 +114,7 @@ then
     echo "asdf.sh already configured"
 else
   if [[ $(uname -m) == 'arm64' ]]; then
-    echo -e "\n. $(brew --prefix asdf)/asdf/asdf.sh" >> ${ZDOTDIR:-~}/.zshrc
+    echo -e "\n. $(brew --prefix asdf)/asdf.sh" >> ${ZDOTDIR:-~}/.zshrc
   else
     echo -e "\n. $(brew --prefix asdf)/libexec/asdf.sh" >> ${ZDOTDIR:-~}/.zshrc
   fi

--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -111,7 +111,11 @@ then
     # noop as already exists
     echo "asdf.sh already configured"
 else
-  echo -e "\n. $(brew --prefix asdf)/libexec/asdf.sh" >> ${ZDOTDIR:-~}/.zshrc
+  if [[ $(uname -m) == 'arm64' ]]; then
+    echo -e "\n. $(brew --prefix asdf)/asdf/asdf.sh" >> ${ZDOTDIR:-~}/.zshrc
+  else
+    echo -e "\n. $(brew --prefix asdf)/libexec/asdf.sh" >> ${ZDOTDIR:-~}/.zshrc
+  fi
   FPATH="$(brew --prefix)/share/zsh/site-functions:${FPATH}" >> ~/.zprofile
 fi
 

--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -113,11 +113,7 @@ then
     # noop as already exists
     echo "asdf.sh already configured"
 else
-  if [[ $(uname -m) == 'arm64' ]]; then
-    echo -e "\n. $(brew --prefix asdf)/asdf.sh" >> ${ZDOTDIR:-~}/.zshrc
-  else
-    echo -e "\n. $(brew --prefix asdf)/libexec/asdf.sh" >> ${ZDOTDIR:-~}/.zshrc
-  fi
+  echo -e "\n$(brew info asdf | grep asdf.sh | sed -e 's/^[ \t]*//')" >> ${ZDOTDIR:-~}/.zshrc
   FPATH="$(brew --prefix)/share/zsh/site-functions:${FPATH}" >> ~/.zprofile
 fi
 


### PR DESCRIPTION
## Why?

Resolves LRE-687

The following is a cursory list of things we need to update in lldevconfig for properly configuring M1 macs.

- Add the right directory to the path for the asdf executable. For M1 macs, we’ll want to do something like this: `$(brew --prefix)/asdf/asdf.sh` instead of [this line](https://github.com/lessonly/lldevconfig/blob/6ba9e566192b00c13983a709241492f53e9037f4/bin/bootstrap#L114).
- When copying the `lessonly.test` resolver to `/etc/resolver/...` we need to make the `/etc/resolver/...` directory first before we copy the file. ([Here](https://github.com/lessonly/lldevconfig/blob/6ba9e566192b00c13983a709241492f53e9037f4/bin/bootstrap#L54) is what we are currently doing.)
- [This line](https://github.com/lessonly/lldevconfig/blob/6ba9e566192b00c13983a709241492f53e9037f4/bin/bootstrap#L63) wasn’t copying the shell script to the right place. We need to do one of the following:
  - Use `$(brew --prefix)` instead of hardcoding a path OR
  - Eliminate the need for the lldev-network-setup.sh and just run the two shell commands inside the file on their own

## What?

- Uses the right path for asdf for M1 macs
- Creates the `/etc/resolver/...` directory if one doesn't exist
- Properly copy and run the `lldev-network-setup.sh` file

## Testing Notes

- [ ] Using an M1 mac, we'll want to make sure `bin/bootstrap` completes successfully
  - Currently, on `main`, you'll see the following errors for `lldev-network-setup.sh`
    ```bash
    cp: /usr/local/bin/lldev-network-setup.sh: Permission denied
    sudo: /usr/local/bin/lldev-network-setup.sh: command not found
    ```
  - On this branch, you'll see the following instead indicating that `lldev-network-setup.sh` was run:
    ```bash
    pfctl: Use of -f option, could result in flushing of rules
    present in the main ruleset added by the system at startup.
    See /etc/pf.conf for further details.

    No ALTQ support in kernel
    ALTQ related functions disabled
    pfctl: pf already enabled
    ``` 
- [ ] We'll also want to test this on an Intel mac as well. We want to ensure that lldevconfig is backwards compatible. 

## Merge Instructions

Please **DO** squash my commits when merging
