### PR TITLE
M1s caddy admin endpoint port collision

### DIFF
--- a/bin/Caddyfile
+++ b/bin/Caddyfile
@@ -14,6 +14,7 @@
 	log {
 		output file /usr/local/var/log/caddy/caddy_access.log
 	}
+	admin localhost:3019
 }
 
 # explicitly list http endpoints so caddy doesn't do


### PR DESCRIPTION
Resolves https://seismic.atlassian.net/browse/LRE-1880

Fixes issue with caddy admin port colliding with another service running on seismic M1s

Run `bin/boostrap` again after this merged or run this command below to restart caddy alone.

```bash
cp bin/Caddyfile $(brew --prefix)/etc/Caddyfile
caddy trust
brew services restart caddy
```