### PR TITLE
Adjust caddy commands to use our caddy config

### DIFF
--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -43,10 +43,11 @@ brew bundle -v
 # - reverse proxy for local *.lessonly.test
 # - automatic local certs
 cp bin/Caddyfile $(brew --prefix)/etc/Caddyfile
+caddy reload --config bin/Caddyfile
 # https://caddyserver.com/docs/automatic-https#local-https
 # add/trust caddy's local root CA certificate
 # it generates intermediate certificates from the root which are used to sign individual site certificates
-caddy trust
+caddy trust --config bin/Caddyfile
 # stop (if necessary) and start the service formula immediately and register it to launch at login.
 brew services restart caddy
 


### PR DESCRIPTION
## Why?

Resolves https://seismic.atlassian.net/browse/LRE-1903

After updating the caddy server to run it’s admin interface on a different port 3019 (instead of the default 2019) the caddy trust fails to run when bin/bootstrap is run.

This works fine in the cases where the root certificate has already been created, but for new laptop setups this causes SSL certs to fail setup even though caddy is running.

<img width="1101" alt="Screen Shot 2022-09-22 at 4 47 55 PM" src="https://user-images.githubusercontent.com/5419727/191848740-594a55b6-8375-47c6-a64a-265253ea5ce4.png">


## What?
- Reload caddy with our Caddyfile Config
- Supply our config to `caddy trust` when adding root caddy cert

## Testing Notes

**New Cert Setup**
- [ ] If you already have your root cert setup, run this command to drop it
    * `caddy untrust --config $(brew --prefix)/etc/Caddyfile`
- [ ] Run `bin/bootstrap`
- [ ] Verify it prompts you to verify security and add the cert
- [ ] Verify it installed correctly with
    * `curl https://caddystatus.lessonly.test`
    * It should return "Caddy works: GET https://caddystatus.lessonly.test/"

<img width="1280" alt="Screen Shot 2022-09-22 at 4 48 50 PM" src="https://user-images.githubusercontent.com/5419727/191849541-28110bad-6c07-4e55-93d2-7d608550d076.png">


**Cert Already Created**
- [ ] With the cert already installed run bootstrap again
    * `bin/bootstrap`
- [ ] Verify it states caddy's cert is already installed
- [ ] Verify it remains installed correctly with
    * `curl https://caddystatus.lessonly.test`
    * It should return "Caddy works: GET https://caddystatus.lessonly.test/"
    
<img width="1284" alt="Screen Shot 2022-09-22 at 4 49 31 PM" src="https://user-images.githubusercontent.com/5419727/191849586-38723244-af22-4f47-bbc5-8bb2fed6fe63.png">


## Merge Instructions

Please **DO** squash my commits when merging
