### PR TITLE
Update Caddyfile for BFF

### DIFF
--- a/bin/Caddyfile
+++ b/bin/Caddyfile
@@ -37,6 +37,7 @@ lessonly.test:8443,
 	}
 	reverse_proxy /skills* 127.0.0.1:3001
 	reverse_proxy /skills/graphql* 127.0.0.1:3002
+	reverse_proxy /readinessBffService* 127.0.0.1:3031
 }
 
 # to test if /etc/hosts, port forwarding, and caddy are working:

--- a/bin/Caddyfile
+++ b/bin/Caddyfile
@@ -37,7 +37,21 @@ lessonly.test:8443,
 	}
 	reverse_proxy /skills* 127.0.0.1:3001
 	reverse_proxy /skills/graphql* 127.0.0.1:3002
-	reverse_proxy /readinessBffService* 127.0.0.1:3031
+}
+
+http://readiness-bff.test:8081,
+readiness-bff.test:8443 {
+	encode zstd gzip
+
+	@https {
+		protocol https
+	}
+	header @https Strict-Transport-Security "max-age=31536000; includeSubDomains; always"
+
+	# https://caddyserver.com/docs/caddyfile/directives/reverse_proxy#https
+	reverse_proxy 127.0.0.1:3031 {
+		header_up Host {upstream_hostport}
+	}
 }
 
 # to test if /etc/hosts, port forwarding, and caddy are working:

--- a/bin/hosts
+++ b/bin/hosts
@@ -17,6 +17,7 @@
 127.0.0.1 seismicintegration.lessonly.test
 127.0.0.1 signup.lessonly.test
 127.0.0.1 webhook.lessonly.test
+127.0.0.1 readiness-bff.test
 # Readiness Company Subdomains
 127.0.0.1 bob.lessonly.test
 127.0.0.1 dev.lessonly.test


### PR DESCRIPTION
## Why?

Supports [[LRE-4826]](https://seismic.atlassian.net/browse/LRE-4826)

When working locally with the BFF when we try to integration in the the Seismic local dev server it's running on HTTPS so we need to have the BFF on HTTPS as well

## What?

This adds a new domain readiness-bff.test to route all traffic to port 3031 where the BFF will be running (See https://github.com/seismic/readiness-bff-service/pull/2)

## Testing Notes

### Setup/Preparation:

- [x] run `bin/bootstrap`
- [x] optional: set up and run the readiness-bff-service project from the above branch

### Feature testing steps:

- [x] verify https://readiness-bff.test goes to port 3031 (something will need to be running on 3031 if you don't run the bff project)
  - if bff project running https://readiness-bff.test/readinessBffService/api-docs/


[LRE-4826]: https://seismic.atlassian.net/browse/LRE-4826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ