### PR TITLE
Update lldevconfig README and bootstrap script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# See http://help.github.com/ignore-files/ for more about ignoring files.
+
+.idea/**/*

--- a/README.md
+++ b/README.md
@@ -11,10 +11,13 @@ When you receive your Lessonly MacBook, start here before setting up other tools
 1. Open a Terminal window and run `git`. This will prompt you to install Xcode tools. Install it.
 2. Open a browser window to https://github.com and log in to Github.
 3. Download and install [Docker for Mac](https://docs.docker.com/docker-for-mac/install/).
+   - **Note**: Some versions of Docker have problems with network connections, either external, or for local access using Caddy.
+     If you have problems with this, you can try installing an older version of Docker. We've had success with version 4.23.0.
+     You can find older versions here: https://docs.docker.com/desktop/release-notes/
    - Once you have it installed, run and log in to the Docker app. You may need to sign up if you haven't done this before.
 4. In your Terminal window, change to the directory where you want git repositories to go, and clone this repo.
    ```sh
-   git clone https://github.com/lessonly/lldevconfig.git
+   git clone git@github.com:lessonly/lldevconfig.git
    cd lldevconfig
    ```
 5. Run the bootstrap script
@@ -29,7 +32,6 @@ When you receive your Lessonly MacBook, start here before setting up other tools
    - Enter a password to protect your SSH key (you will be asked 3 times)
    - Add your SSH key in Github. It should copy the key and open a page to [the Github SSH keys page](https://github.com/settings/keys) for you to make it easy.
 6. Once this script completes, you should close this window and open a new terminal so that it loads zsh.
-7. If you running a Mac with an Apple silicon CPU (M1/M2) please run the Apple Silicon MacOS laptop steps additionally below before setting up projects just yet.
 
 At this point, you have everything you need to clone a project and follow its setup instructions. We recommend visiting https://github.com/lessonly/lessonly#getting-started and following the setup instructions there, first. That's our core app and most likely where you'll be spending more of your time.
 

--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -1,9 +1,28 @@
 #!/bin/bash
 CURRENT_USER=`whoami`
 
-if [ $CURRENT_USER = "root" ]; then
-echo "Please run this as your normal user, not root"
-exit 1
+if [ "$CURRENT_USER" = "root" ]; then
+  echo "Please run this as your normal user, not root"
+  exit 1
+fi
+
+# Enable key repeat.  Editors are super awkward without this
+defaults write -g ApplePressAndHoldEnabled -bool false
+
+# Install Homebrew
+which -s brew
+if [[ $? != 0 ]] ; then
+  echo "Homebrew not found. Installing it..."
+  # The Ruby Homebrew installer has been rewritten in Bash
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+  # If installed to /opt/homebrew, setup homebrew in path for future and current shell
+  if [[ -f "/opt/homebrew/bin/brew" ]]; then
+    echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> "/Users/$CURRENT_USER/.zprofile"
+    eval "$(/opt/homebrew/bin/brew shellenv)"
+  fi
+else
+  echo "Homebrew found. Updating it..."
+  brew update
 fi
 
 # Uninstall salt
@@ -26,24 +45,6 @@ if command -v dnsmasq &> /dev/null ; then
   brew uninstall dnsmasq
 fi
 
-# Enable key repeat.  Editors are super awkward without this
-defaults write -g ApplePressAndHoldEnabled -bool false
-
-# Install Homebrew
-which -s brew
-if [[ $? != 0 ]] ; then
-  echo "Homebrew not found. Installing it..."
-  # The Ruby Homebrew installer has been rewritten in Bash
-  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-  # If installed to /opt/homebrew, setup homebrew in path for future and current shell
-  if [[ -f "/opt/homebrew/bin/brew" ]]; then
-    echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> "/Users/$CURRENT_USER/.zprofile"
-    eval "$(/opt/homebrew/bin/brew shellenv)"
-  fi
-else
-  echo "Homebrew found. Updating it..."
-  brew update
-fi
 # Install Dependencies via Brewfile
 brew bundle -v
 
@@ -117,8 +118,8 @@ fi
 # https://asdf-vm.com/guide/getting-started.html#_3-install-asdf
 if grep -q "asdf.sh" ${ZDOTDIR:-~}/.zshrc
 then
-    # noop as already exists
-    echo "asdf.sh already configured"
+  # noop as already exists
+  echo "asdf.sh already configured"
 else
   echo -e "\n$(brew info asdf | grep asdf.sh | sed -e 's/^[ \t]*//')" >> ${ZDOTDIR:-~}/.zshrc
   FPATH="$(brew --prefix)/share/zsh/site-functions:${FPATH}" >> ~/.zprofile


### PR DESCRIPTION
## Why?

Resolves [LCM-124](https://seismic.atlassian.net/browse/LCM-124)

The setup instructions are out of date, order of some operations for the bootstrap script was unintuitive.
Additionally, the latest version of Docker Desktop at the time of these changes has intermittent network issues.

## What?

Updates the README to remove information that is out of date, add information about the recommended Docker Desktop version if experiencing network problems, and some minor (non-functional) changes to the bootstrap script.

Also added a .gitignore for IntelliJ files for anyone who might be using an IntelliJ IDE.

## Testing Notes

Do the updated sections of the README make sense?
Does the bootstrap script run without errors?

## Merge Instructions

Please **DO NOT** squash my commits when merging. I think it would be good to keep them separate.


[LCM-124]: https://seismic.atlassian.net/browse/LCM-124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ