### PR TITLE
Set up Caddy log directory in bootstrap script

### DIFF
--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -1,6 +1,9 @@
 #!/bin/bash
 CURRENT_USER=`whoami`
 
+# Matches output file in Caddyfile
+CADDY_LOG_DIR="/usr/local/var/log/caddy"
+
 if [ "$CURRENT_USER" = "root" ]; then
   echo "Please run this as your normal user, not root"
   exit 1
@@ -56,6 +59,18 @@ sudo sh -c 'cat bin/hosts >> /etc/hosts'
 # Configure Caddy
 # - reverse proxy for local *.lessonly.test
 # - automatic local certs
+
+# Make sure Caddy log path exists and is writable by the current user.
+if [ ! -d "$CADDY_LOG_DIR" ] || [ ! -w "$CADDY_LOG_DIR" ]; then
+  echo "Setting up Caddy log directory ($CADDY_LOG_DIR)"
+  sudo mkdir -p $CADDY_LOG_DIR
+  sudo chown -R $CURRENT_USER $CADDY_LOG_DIR
+  chmod -R 755 $CADDY_LOG_DIR
+
+  # Restart service for remaining caddy commands to work
+  brew services restart caddy
+fi
+
 cp bin/Caddyfile $(brew --prefix)/etc/Caddyfile
 caddy reload --config bin/Caddyfile
 # https://caddyserver.com/docs/automatic-https#local-https


### PR DESCRIPTION
### Why?

Caddy requires a writable log directory to function correctly. This setup ensures that the log directory exists and has the appropriate permissions.

### What?

The bootstrap script now includes logic to create the Caddy log directory if it does not exist and sets the correct ownership and permissions.

### Testing Notes

Run the bootstrap script as a normal user and verify that the log directory is created at `/usr/local/var/log/caddy` with the correct permissions.

You may need to remove write permissions for your current user (`whoami`) for the path or delete it entirely to test this properly.

### Caveats

Mess with your local environment at your own peril! Ok, fine, if this messes it up while you are testing, let me know and I'll help sort it out.